### PR TITLE
Added automated build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build EiEiEi with platformio 
+on:
+  push:
+    branches: 
+      - '*'
+  pull_request:
+
+jobs:
+
+  install_platformio_and_build_eieiei:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2.2.1
+
+    - name: Install pio and its dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install platformio
+    - name: Run PlatformIO build on selected platforms
+      run: platformio run 

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,5 @@ lib_deps =
     adafruit/Adafruit SSD1306 @ ^2.4.3
     adafruit/Adafruit MQTT Library @ ^2.1.0
     ricaun/ArduinoUniqueID @ ^1.1.0
+lib_ignore =
+  WiFi101


### PR DESCRIPTION
Added a workflow file for an automated build with platformio.
I had to explicitly exclude the Wifi101 library, because it colides with the esp wifi library if wifi101 is installed in the global platformio library directory.