### PR TITLE
Added automated upload of build artifacts after automated build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,21 @@ jobs:
     - name: Run PlatformIO build on selected platforms
       run: platformio run 
       
-    - name: Upload Artifact
+    - name: Upload .bin file
       if: success()
       uses: actions/upload-artifact@v2
       with:
         name: firmware.bin
         path: .pio/build/eieiei_esp32dev/firmware.bin
-        retention-days: 5       
+        retention-days: 5   
+        
+    - name: Upload .elf file
+      if: success()
+      uses: actions/upload-artifact@v2
+      with:
+        name: firmware.elf
+        path: .pio/build/eieiei_esp32dev/firmware.elf
+        retention-days: 5   
         
         
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,15 @@ jobs:
       run: mv tamaguino/settings.h.example tamaguino/settings.h           
     - name: Run PlatformIO build on selected platforms
       run: platformio run 
+      
+    - name: Upload Artifact
+      if: success()
+      uses: actions/upload-artifact@v2
+      with:
+        name: firmware.bin
+        path: .pio/build/eieiei_esp32dev/firmware.bin
+        retention-days: 5
+        
+        
+        
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,7 @@ jobs:
       with:
         name: firmware.bin
         path: .pio/build/eieiei_esp32dev/firmware.bin
-        retention-days: 5
-        
+        retention-days: 5       
         
         
         


### PR DESCRIPTION
As you said, an automated upload of the build artifacts would be nice.

As you can see in the picture, the build output is archived after a successfully completed build actions:
![Screenshot from 2021-04-06 20-55-22](https://user-images.githubusercontent.com/42242163/113763976-a0580900-971a-11eb-91ff-d1139599dfd3.png)

